### PR TITLE
[FEATURE] - Enforce Light Mode & Add Photo Library Permission Handling

### DIFF
--- a/About-You.xcodeproj/xcshareddata/xcschemes/About-You.xcscheme
+++ b/About-You.xcodeproj/xcshareddata/xcschemes/About-You.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5D90F2D526DB774400EFA4A8"
+               BuildableName = "About-You.app"
+               BlueprintName = "About-You"
+               ReferencedContainer = "container:About-You.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5D90F2D526DB774400EFA4A8"
+            BuildableName = "About-You.app"
+            BlueprintName = "About-You"
+            ReferencedContainer = "container:About-You.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5D90F2D526DB774400EFA4A8"
+            BuildableName = "About-You.app"
+            BlueprintName = "About-You"
+            ReferencedContainer = "container:About-You.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/About-You/Info.plist
+++ b/About-You/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>This app needs access to your photo library to allow you to upload a profile picture.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/About-You/Main Files (Free to change)/Controllers/EngineersTableViewController.swift
+++ b/About-You/Main Files (Free to change)/Controllers/EngineersTableViewController.swift
@@ -16,6 +16,7 @@ class EngineersTableViewController: UITableViewController, UIPopoverPresentation
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Engineers at Glucode"
+        overrideUserInterfaceStyle = .light
         tableView.backgroundColor = .white
         registerCells()
     }

--- a/About-You/Main Files (Free to change)/Controllers/OrderByTableViewController.swift
+++ b/About-You/Main Files (Free to change)/Controllers/OrderByTableViewController.swift
@@ -8,6 +8,7 @@ class OrderByTableViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        overrideUserInterfaceStyle = .light
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: String(describing: UITableViewCell.self))
     }
     

--- a/About-You/Main Files (Free to change)/Controllers/QuestionsViewController.swift
+++ b/About-You/Main Files (Free to change)/Controllers/QuestionsViewController.swift
@@ -17,6 +17,7 @@ class QuestionsViewController: UIViewController, UIScrollViewDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        overrideUserInterfaceStyle = .light
         view.backgroundColor = .white
         title = "About"
         scrollView.delegate = self


### PR DESCRIPTION
**Summary:**

- Enforced light mode across the app to prevent UI inconsistencies in dark mode.
- Added NSPhotoLibraryUsageDescription to Info.plist to prevent crashes when accessing the photo library.
- Implemented photo library permission request before presenting the image picker.


https://github.com/user-attachments/assets/acf056ee-2796-4da0-b15e-00231c25b01e

